### PR TITLE
C++23 Test

### DIFF
--- a/src/vulkan/vulkan-device.cpp
+++ b/src/vulkan/vulkan-device.cpp
@@ -22,6 +22,7 @@
 
 #include "vulkan-backend.h"
 #include <unordered_map>
+#include <sstream>  // XML: this needs to be explicitly #include'd
 
 #include <nvrhi/common/misc.h>
 

--- a/src/vulkan/vulkan-raytracing.cpp
+++ b/src/vulkan/vulkan-raytracing.cpp
@@ -20,6 +20,8 @@
 * DEALINGS IN THE SOFTWARE.
 */
 
+#include <sstream>
+
 #include "vulkan-backend.h"
 #include <nvrhi/common/misc.h>
 

--- a/src/vulkan/vulkan-resource-bindings.cpp
+++ b/src/vulkan/vulkan-resource-bindings.cpp
@@ -20,6 +20,8 @@
 * DEALINGS IN THE SOFTWARE.
 */
 
+#include <sstream>
+
 #include "vulkan-backend.h"
 #include <nvrhi/common/misc.h>
 


### PR DESCRIPTION
Changing the language version in Visual Studio to C++23 (preview) apparently requires explicit inclusion of <sstream>, since string literals no longer auto-cast to char* -- I'm not sure why those headers weren't #include'd in the first place.